### PR TITLE
fix: теперь дубликат лайка тоже должен возвращать успешный ответ сервера

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -2,6 +2,7 @@ package ru.yandex.practicum.filmorate.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import ru.yandex.practicum.filmorate.exception.FilmNotFoundException;
 import ru.yandex.practicum.filmorate.model.Director;
@@ -73,20 +74,23 @@ public class FilmService {
     }
 
     public boolean likeFilm(Integer filmId, Integer userId) {
-        if (likeStorage.save(filmId, userId)) {
+        try {
+            likeStorage.save(filmId, userId);
             log.info("Пользователь с id {} поставил лайк фильму с id {}", userId, filmId);
 
+            return true;
+        } catch (DataAccessException e) {
+            return false;
+        } finally {
             Event event = Event.builder()
                     .userId(userId)
                     .entityId(filmId)
                     .eventType(LIKE)
                     .operation(ADD)
                     .build();
-            eventStorage.save(event);
 
-            return true;
+            eventStorage.save(event);
         }
-        return false;
     }
 
     public boolean dislikeFilm(Integer filmId, Integer userId) {


### PR DESCRIPTION
Мария писала в группе: 

> на всякий случай: в финальных тестах develop два раза добавляется лайк фильму 3 от юзера 1, и оба раза должен записываться feed.

Исправил чтобы дубликат лайка не вызывал ошибку сервера 500. Так же feed должен пополняться событием в любом случае, исправил